### PR TITLE
Update kata's JavaScript version

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,13 +1,15 @@
 {
   "name": "bank-refactoring-kata",
   "version": "1.0.0",
-  "description": "",
+  "description": "Refactoring the Bank Kata",
+  "license": "MIT",
+  "author": "",
   "main": "./src/bank.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
-  "license": "MIT",
+  "dependencies": {
+  },
   "devDependencies": {
     "jest": "^29.7.0"
   }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "jest": "^29.7.0"
   }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "main": "./src/bank.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest --colors",
+    "test:coverage": "jest --colors --coverage"
   },
   "dependencies": {
   },

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -2,7 +2,7 @@
   "name": "bank-refactoring-kata",
   "version": "1.0.0",
   "description": "",
-  "main": "bank.js",
+  "main": "./src/bank.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Hi,

I would like to propose a few changes to the JavaScript version:
- change the license to the MIT license (as it was mentioned in the Python version)
- specify a full path in the main field
- add commands to the `scripts` section (it is better to give the possibility to just run tests without the necessity to remember how to run them)
- some improvements